### PR TITLE
Update naming convention for enums

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -76,14 +76,15 @@ class Guideline {
 
 ### Enumerations
 
-Use UpperCamelCase for enumeration values:
+Use lowerCamelCase for enumeration values:
 
 ```swift
 enum Shape {
-    case Rectangle
-    case Square
-    case Triangle
-    case Circle
+    case rectangle
+    case square
+    case triangle
+    case circle
+    case equilateralTriangle
 }
 ```
 


### PR DESCRIPTION
Updates to follow swift 3 standard library naming conventions for enums
