### PR TITLE
OptionSetTypes are now OptionSets

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -30,7 +30,7 @@
   * [Optionals](#optionals)
   * [Struct Initializers](#struct-initializers)
   * [Lazy Initialization](#lazy-initialization)
-  * [OptionSetTypes](#optionsettypes)
+  * [OptionSets](#optionsets)
   * [Type Inference](#type-inference)
   * [Syntactic Sugar](#syntactic-sugar)
 * [Working with Storyboards](#storyboards)
@@ -685,12 +685,12 @@ private func makeLocationManager() -> CLLocationManager {
   - `[unowned self]` is not required here. A retain cycle is not created.
   - Location manager has a side-effect for popping up UI to ask the user for permission so fine grain control makes sense here.
 
-### OptionSetTypes
+### OptionSets
 
-When using OptionSetTypes, signify the "no" option using an empty array literal rather than the rawValue initializer. For example, given:
+When using OptionSets, signify the "no" option using an empty array literal rather than the rawValue initializer. For example, given:
 
 ```swift
-struct PackagingOptions : OptionSetType {
+struct PackagingOptions : OptionSet {
     let rawValue: Int
     init(rawValue: Int) { self.rawValue = rawValue }
     static let box = PackagingOptions(rawValue: 1)


### PR DESCRIPTION
Swift 3.0 now exclusively uses the `OptionSet` syntax and no longer allows `OptionSetType`
Output from Xcode:

```
Playground execution failed: error: RPG Armor Options.playground:5:23: error: 'OptionSetType' has been renamed to 'OptionSet'
struct ArmorOptions : OptionSetType {
                      ^~~~~~~~~~~~~
                      OptionSet
```
